### PR TITLE
fix tray icon

### DIFF
--- a/HomeassistantApp.qml
+++ b/HomeassistantApp.qml
@@ -14,7 +14,7 @@ App {
 
     property url trayUrl: "HomeassistantTray.qml"
     property SystrayIcon homeAssistantTray: SystrayIcon {}
-    property string iconSwitch: "no"
+    property string iconSwitch: "yes"
 
     property HomeassistantConfigurationScreen homeAssistantConfigurationScreen
     property url homeAssistantConfigurationScreenUrl : "HomeassistantConfigurationScreen.qml"

--- a/HomeassistantTray.qml
+++ b/HomeassistantTray.qml
@@ -16,6 +16,6 @@ SystrayIcon {
 	Image {
 		id: imghomeAssistant
 		anchors.centerIn: parent
-		source: "qrc:/tsc/homeAssistantSystrayIcon.png"
+		source: "qrc:/tsc/homeAssistant.png"
 	}
 }


### PR DESCRIPTION
Tray icon wordt nu correct getoond. Twee wijzigingen:
..Tray.qml:  correcte naam van het icon
..App.qml: variabele iconSwitch stond op "no" waardoor er in regel 802 de tegel niet werd geinitialiseerd.

Note: specifiek voor systray icons: die moeten voorkomen in tsc_images , je kan geen eigen icons toevoegen voor de tray, wel in de app zelf (https://github.com/ToonSoftwareCollective/tsc-images)